### PR TITLE
Update bindgen to fix build problems in Fedora (v4l2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,13 @@ authors = ["Christopher N. Hesse <raymanfx@gmail.com>"]
 edition = "2018"
 license = "MIT"
 readme = "README.md"
-repository= "https://github.com/raymanfx/libv4l-rs"
+repository = "https://github.com/raymanfx/libv4l-rs"
 
 [dependencies]
 bitflags = "1.2.1"
 libc = "0.2"
 v4l-sys = { path = "v4l-sys", version = "0.2.0", optional = true }
-v4l2-sys = { path = "v4l2-sys", version = "0.2.0", package="v4l2-sys-mit", optional = true }
+v4l2-sys = { path = "v4l2-sys", version = "0.2.0", package = "v4l2-sys-mit", optional = true }
 thiserror = "1.0"
 errno = "0.2"
 
@@ -26,7 +26,4 @@ libv4l = ["v4l-sys"]
 v4l2 = ["v4l2-sys"]
 
 [workspaces]
-members = [
-    "v4l-sys",
-    "v4l2-sys",
-]
+members = ["v4l-sys", "v4l2-sys"]

--- a/v4l-sys/Cargo.toml
+++ b/v4l-sys/Cargo.toml
@@ -9,4 +9,4 @@ links = "v4l1 v4l2 4lconvert"
 build = "build.rs"
 
 [build-dependencies]
-bindgen = "0.56.0"
+bindgen = "0.65.1"

--- a/v4l2-sys/Cargo.toml
+++ b/v4l2-sys/Cargo.toml
@@ -8,4 +8,4 @@ license = "MIT"
 build = "build.rs"
 
 [build-dependencies]
-bindgen = "0.56.0"
+bindgen = "0.65.1"


### PR DESCRIPTION
Original issue: https://github.com/HULKs/hulk/issues/352

Further digging found that the upstream (14.x) works fine which has an updated `bindgen` version. To keep things simple I updated bindgen in `v4l-sys` crates to latest `bindgen` to have least changes with HULKs patches.